### PR TITLE
Fixes #1 - Change from COMMIT to VERSION for rundeck-cli build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build:
       context: rundeck-plugin-bootstrap
       args:
-        COMMIT: c3ebc59c35eb824d359c04370127aff4e64e6d70
+        VERSION: "0.4.9"
     image: playground-rundeck-plugin-bootstrap
 
   # backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     build:
       context: rundeck-cli
       args:
-        COMMIT: f20b69dc8e43462bf71a78dcb549997c86a51995
+        VERSION: "1.3.10"
     image: playground-rundeck-cli
   
   # plugin bootstrap tool

--- a/rundeck-cli/Dockerfile
+++ b/rundeck-cli/Dockerfile
@@ -1,11 +1,8 @@
 FROM openjdk:8-jdk
 COPY --from=gradle:jdk8 /opt/gradle /opt/gradle
 RUN ln -s /opt/gradle/bin/gradle /usr/bin/gradle
-ARG COMMIT
-RUN mkdir /root/rd && curl -sL https://github.com/rundeck/rundeck-cli/archive/${COMMIT}.zip > /root/rd/rd.zip
+ARG VERSION
+RUN mkdir /root/rd && curl -sL https://github.com/rundeck/rundeck-cli/releases/download/v${VERSION}/rd-${VERSION}.zip > /root/rd/rd.zip
 RUN cd /root/rd/ \
     && unzip rd.zip \
-    && cd rundeck-cli-${COMMIT} \
-    && gradle --no-daemon :distZip
-RUN unzip -d /root/tools /root/rd/rundeck-cli-${COMMIT}/build/distributions/rd-0.1.0-SNAPSHOT.zip \
-    && rm -rf /root/rd
+    && mv rd-${VERSION}/bin/rd /usr/local/openjdk-8/bin

--- a/rundeck-plugin-bootstrap/Dockerfile
+++ b/rundeck-plugin-bootstrap/Dockerfile
@@ -1,12 +1,8 @@
 FROM openjdk:8-jdk
 COPY --from=gradle:jdk8 /opt/gradle /opt/gradle
 RUN ln -s /opt/gradle/bin/gradle /usr/bin/gradle
-ARG COMMIT
-RUN mkdir /root/plugin-bootstrap && curl -sL https://github.com/rundeck/plugin-bootstrap/archive/${COMMIT}.zip > /root/plugin-bootstrap/plugin-bootstrap.zip
+ARG VERSION
+RUN mkdir /root/plugin-bootstrap && wget https://github.com/rundeck/plugin-bootstrap/releases/download/${VERSION}/rundeck-plugin-bootstrap-${VERSION}.zip -P /root/plugin-bootstrap
 RUN cd /root/plugin-bootstrap \
-    && unzip plugin-bootstrap.zip \
-    && rm plugin-bootstrap.zip \
-    && cd plugin-bootstrap-${COMMIT} \
-    && gradle --no-daemon build :distZip
-RUN unzip -d /root/tools/ /root/plugin-bootstrap/plugin-bootstrap-${COMMIT}/build/distributions/rundeck-plugin-bootstrap-0.1.0-SNAPSHOT.zip \
-    && rm -rf /root/plugin-bootstrap
+    && unzip rundeck-plugin-bootstrap-${VERSION}.zip \
+    && mv rundeck-plugin-bootstrap-${VERSION}/bin/rundeck-plugin-bootstrap /usr/local/openjdk-8/bin


### PR DESCRIPTION
Rather than using COMMIT hashes and downloading from repository archives, I've changed it to reference the VERSION of rundeck-cli.  Also, you no longer need to build the CLI with Gradle, instead it downloads from the zip file already compiled.  I simply move the `rd` executable to a location in the container's `$PATH`.