### PR TITLE
Fixing build failures

### DIFF
--- a/rundeck-cli/Dockerfile
+++ b/rundeck-cli/Dockerfile
@@ -6,6 +6,6 @@ RUN mkdir /root/rd && curl -sL https://github.com/rundeck/rundeck-cli/archive/${
 RUN cd /root/rd/ \
     && unzip rd.zip \
     && cd rundeck-cli-${COMMIT} \
-    && gradle --no-daemon :distZip
+    && ./gradlew distZip
 RUN unzip -d /root/tools /root/rd/rundeck-cli-${COMMIT}/build/distributions/rd-0.1.0-SNAPSHOT.zip \
     && rm -rf /root/rd

--- a/rundeck-plugin-bootstrap/Dockerfile
+++ b/rundeck-plugin-bootstrap/Dockerfile
@@ -7,6 +7,6 @@ RUN cd /root/plugin-bootstrap \
     && unzip plugin-bootstrap.zip \
     && rm plugin-bootstrap.zip \
     && cd plugin-bootstrap-${COMMIT} \
-    && gradle --no-daemon build :distZip
+    && ./gradlew distZip
 RUN unzip -d /root/tools/ /root/plugin-bootstrap/plugin-bootstrap-${COMMIT}/build/distributions/rundeck-plugin-bootstrap-0.1.0-SNAPSHOT.zip \
     && rm -rf /root/plugin-bootstrap

--- a/rundeck/Dockerfile
+++ b/rundeck/Dockerfile
@@ -1,7 +1,8 @@
 FROM rundeck/rundeck:SNAPSHOT
 
-COPY --chown=rundeck:rundeck ssh /home/rundeck/.ssh
+COPY --chown=rundeck:root ssh /home/rundeck/.ssh
 RUN chmod 0700 /home/rundeck/.ssh \
     && chmod 0600 /home/rundeck/.ssh/* \
     && chmod 0644 /home/rundeck/.ssh/*.pub
-COPY --chown=rundeck:rundeck nodes.yaml /home/rundeck/
+RUN ls -lah /home/rundeck/.ssh
+COPY --chown=rundeck:root nodes.yaml /home/rundeck/

--- a/rundeck/Dockerfile
+++ b/rundeck/Dockerfile
@@ -4,5 +4,4 @@ COPY --chown=rundeck:root ssh /home/rundeck/.ssh
 RUN chmod 0700 /home/rundeck/.ssh \
     && chmod 0600 /home/rundeck/.ssh/* \
     && chmod 0644 /home/rundeck/.ssh/*.pub
-RUN ls -lah /home/rundeck/.ssh
 COPY --chown=rundeck:root nodes.yaml /home/rundeck/


### PR DESCRIPTION
The `make` command will fail as per issue #1 
I tried the changes from PR #3 but it did not work for me. I eventually figured out the best solution is to simply use the gradle wrapper to build the various tools and not gradle that comes with the container. 

There was also an issue later on with regards to copying in the ssh key. It looks like there is no `rundeck` group so the chown fails when copying. Setting the user to `rundeck` and the group to `root` does work.